### PR TITLE
Protect last sent snapshot as good parent

### DIFF
--- a/snapbtrex.py
+++ b/snapbtrex.py
@@ -1,4 +1,4 @@
-info.learnmore4a@gmail.com#!/usr/bin/python2.7
+#!/usr/bin/python2.7
 # -*- coding: utf-8 -*-
 #
 # Author: Helge Jensen <hej@actua.dk>
@@ -916,7 +916,7 @@ def main(argv):
             try:
                 transfer(operations, pa.remote_host, pa.remote_dir, pa.remote_link, pa.ssh_port, pa.rate_limit)
                 if pa.remote_keep is not None:
-                remotecleandir(operations, pa.remote_host, pa.remote_dir, pa.remote_keep, pa.ssh_port)
+                    remotecleandir(operations, pa.remote_host, pa.remote_dir, pa.remote_keep, pa.ssh_port)
             except RuntimeError as e:
                 trace(LOG_REMOTE + "Error while transferring to remote host: %s", e)
                 


### PR DESCRIPTION
If the host is away from the remote while snapshots done then the last-sent snapshot (which is the best parent for future send operations) can be cleaned out.
The name of the last sent snapshot is stored in a file in the snapshot area whenever a send operation occurs.
This is read every time cleandirs is run, and the listed snapshot is removed from potential deletion

Also test for availability of remote host before trying to send (relies on ping, so not 100% robust)